### PR TITLE
External token management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .idea
+.vscode/settings.json

--- a/athena_health.gemspec
+++ b/athena_health.gemspec
@@ -1,13 +1,12 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'athena_health/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'athena_health'
   spec.version       = AthenaHealth::VERSION
-  spec.authors       = ["Mateusz Urbański"]
-  spec.email         = ['mateuszurbanski@yahoo.pl']
+  spec.authors       = ['Mateusz Urbański', 'Ben Jones']
+  spec.email         = ['mateuszurbanski@yahoo.pl', 'ben@benjones.io']
 
   spec.summary       = 'Ruby wrapper for Athenahealth API.'
   spec.description   = 'Ruby wrapper for Athenahealth API. See https://developer.athenahealth.com/io-docs for more details.'
@@ -25,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'vcr', '~> 3.0'
+  spec.add_development_dependency 'timecop', '~> 0.9.6'
+  spec.add_development_dependency 'rubocop', '~> 1.42'
 end

--- a/lib/athena_health.rb
+++ b/lib/athena_health.rb
@@ -3,6 +3,7 @@ require 'virtus'
 
 require 'athena_health/version'
 require 'athena_health/connection'
+require 'athena_health/auth_token'
 require 'athena_health/error'
 require 'athena_health/endpoints/practices'
 require 'athena_health/endpoints/departments'

--- a/lib/athena_health/auth_token.rb
+++ b/lib/athena_health/auth_token.rb
@@ -1,0 +1,69 @@
+require 'json'
+
+module AthenaHealth
+  class AuthToken
+    def initialize(client_id:, secret:, base_url:, api_version:, auth_token_hash: nil)
+      @base_url = base_url
+      @api_version = api_version
+      @client_id = client_id
+      @secret = secret
+      reset!
+      parse_auth_token_hash!(auth_token_hash) unless auth_token_hash.nil?
+    end
+
+    def auth_header
+      { 'Authorization' => "Bearer #{token}" }
+    end
+
+    def reset!
+      @access_token = nil
+      @expires_at = nil
+    end
+
+    def serialized_token
+      {
+        'access_token' => token,
+        'expires_at' => @expires_at.to_i
+      }
+    end
+
+    private
+
+    def token
+      fetch_token! unless valid?
+      @access_token
+    end
+
+    def valid?
+      !@access_token.nil? &&
+        !@expires_at.nil? &&
+        @expires_at > Time.now
+    end
+
+    def parse_auth_token_hash!(auth_token_hash)
+      # make sure it has the right parts
+      return unless auth_token_hash['access_token'].instance_of? String
+      return unless auth_token_hash['expires_at'].instance_of? Integer
+
+      @access_token = auth_token_hash['access_token']
+      @expires_at = Time.at(auth_token_hash['expires_at'])
+    end
+
+    def fetch_token!
+      reset!
+      initiated_at = Time.now
+      response = Typhoeus.post(
+        "#{@base_url}/oauth2/#{@api_version}/token",
+        userpwd: "#{@client_id}:#{@secret}",
+        body: {
+          grant_type: 'client_credentials',
+          scope: 'athena/service/Athenanet.MDP.*'
+        }
+      )
+      token_hash = JSON.parse(response.response_body)
+      expires_in = token_hash['expires_in'].to_i
+      @access_token = token_hash['access_token']
+      @expires_at = initiated_at + expires_in
+    end
+  end
+end

--- a/lib/athena_health/client.rb
+++ b/lib/athena_health/client.rb
@@ -1,12 +1,25 @@
 module AthenaHealth
   class Client
-    def initialize(production: false, client_id:, secret:, token: nil)
-      @api = AthenaHealth::Connection.new(
-        production: production,
+    PRODUCTION_BASE_URL = 'https://api.platform.athenahealth.com'.freeze
+    PREVIEW_BASE_URL = 'https://api.preview.platform.athenahealth.com'.freeze
+    API_VERSION = 'v1'.freeze
+
+    def initialize(client_id:, secret:, production: false, auth_token_hash: nil)
+      base_url = Client.base_url(production: production)
+      @token = AthenaHealth::AuthToken.new(
         client_id: client_id,
         secret: secret,
-        token: token,
+        auth_token_hash: auth_token_hash,
+        base_url: base_url,
+        api_version: API_VERSION
       )
+      @api = AthenaHealth::Connection.new(
+        base_url: base_url, api_version: API_VERSION, token: @token
+      )
+    end
+
+    def serialized_token
+      @token.serialized_token
     end
 
     include Endpoints::Practices
@@ -20,5 +33,9 @@ module AthenaHealth
     include Endpoints::Subscriptions
     include Endpoints::Claims
     include Endpoints::CustomFields
+
+    def self.base_url(production:)
+      production ? PRODUCTION_BASE_URL : PREVIEW_BASE_URL
+    end
   end
 end

--- a/spec/lib/auth_token_spec.rb
+++ b/spec/lib/auth_token_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'timecop'
+
+describe AthenaHealth::AuthToken do
+  let(:token_attributes) do
+    {
+      client_id: 'test_key',
+      secret: 'test_secret',
+      auth_token_hash: auth_token_hash,
+      base_url: AthenaHealth::Client.base_url(production: production),
+      api_version: AthenaHealth::Client::API_VERSION
+    }
+  end
+
+  let(:production) { true }
+  let(:key_result) { 'unset key_result' }
+  let(:auth_token_hash) do
+    {
+      'access_token' => key_result,
+      'expires_at' => Time.now.to_i + 3600
+    }
+  end
+  let(:freeze_time) { Time.at(1_673_280_861) }
+
+  let(:auth_token) { AthenaHealth::AuthToken.new(**token_attributes) }
+
+  describe 'pase and serialize' do
+    it 'serialzes to the same as the parse' do
+      key_result = auth_token.serialized_token
+      expect(key_result).to eq auth_token_hash
+    end
+  end
+
+  describe '#authenticate' do
+    context 'when production is true' do
+      let(:production) { true }
+      let(:key_result) { 'prod_test_access_token' }
+      let(:auth_token_hash) { nil }
+      it 'returns token' do
+        Timecop.freeze(freeze_time) do
+          VCR.use_cassette('production_authentication', match_requests_on: %i[uri body headers]) do
+            key_result = auth_token.serialized_token
+            expect(key_result['access_token']).to eq 'prod_test_access_token'
+            expect(key_result['expires_at']).to eq(freeze_time.to_i + 3600)
+          end
+        end
+      end
+    end
+
+    context 'when production is false' do
+      let(:production) { false }
+      let(:key_result) { 'test_access_token' }
+      let(:auth_token_hash) { nil }
+      it 'returns token' do
+        Timecop.freeze(freeze_time) do
+          VCR.use_cassette('preview_authentication', match_requests_on: %i[uri body headers]) do
+            key_result = auth_token.serialized_token
+            expect(key_result['access_token']).to eq 'test_access_token'
+            expect(key_result['expires_at']).to eq(freeze_time.to_i + 3600)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -2,10 +2,18 @@ require 'spec_helper'
 
 describe AthenaHealth::Client do
   describe '#initialize' do
-    it 'creates new instance of AthenaHealth::Connection' do
-      expect(AthenaHealth::Connection).to receive(:new).with(client_attributes.merge({production: false}))
-
+    it 'creates new instance of AthenaHealth::AuthToken' do
+      expect(AthenaHealth::AuthToken).to receive(:new).with(
+        client_attributes.slice(:client_id, :secret, :auth_token_hash)
+        .merge(
+          { api_version: 'v1', base_url: 'https://api.preview.platform.athenahealth.com' }
+        )
+      )
       client
+    end
+
+    it 'generates the auth hash' do
+      expect(client.serialized_token).to eq(client_attributes[:auth_token_hash])
     end
   end
 end

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -2,7 +2,10 @@ def client_attributes
   {
     client_id: (ENV['ATHENA_TEST_CLIENT_ID'] || 'test_client_id'),
     secret: (ENV['ATHENA_TEST_SECRET'] || 'test_secret'),
-    token: (ENV['ATHENA_TEST_ACCESS_TOKEN'] || 'test_access_token')
+    auth_token_hash: {
+      'expires_at' => Time.now.to_i + 3600,
+      'access_token' => ENV['ATHENA_TEST_ACCESS_TOKEN'] || 'test_access_token'
+    }
   }
 end
 


### PR DESCRIPTION
Allow developers to manage the auth token externally, this can be useful when sharing the same creds across processeses