### PR TITLE
feat: add orders subscriptions

### DIFF
--- a/lib/athena_health/endpoints/subscriptions.rb
+++ b/lib/athena_health/endpoints/subscriptions.rb
@@ -8,86 +8,122 @@ module AthenaHealth
           collection_class: 'AppointmentCollection',
           path: 'appointments',
           name: 'appointment',
-          plural_name: 'appointments'
+          plural_name: 'appointments',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'PatientCollection',
           path: 'patients',
           name: 'patient',
-          plural_name: 'patients'
+          plural_name: 'patients',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'ProviderCollection',
           path: 'providers',
           name: 'provider',
-          plural_name: 'providers'
+          plural_name: 'providers',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'PatientProblemCollection',
           path: 'chart/healthhistory/problems',
           name: 'patient_problem',
-          plural_name: 'patient_problems'
+          plural_name: 'patient_problems',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'UserAllergyCollection',
           path: 'chart/healthhistory/allergies',
           name: 'patient_allergy',
-          plural_name: 'patient_allergies'
+          plural_name: 'patient_allergies',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'PrescriptionCollection',
           path: 'prescriptions',
           name: 'prescription',
-          plural_name: 'prescriptions'
+          plural_name: 'prescriptions',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'UserMedicationCollection',
           path: 'chart/healthhistory/medication',
           name: 'patient_medication',
-          plural_name: 'patient_medications'
+          plural_name: 'patient_medications',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'PrescriptionCollection',
           path: 'prescriptions',
           name: 'prescription',
-          plural_name: 'prescriptions'
+          plural_name: 'prescriptions',
+          operations: ['changed'],
+          event_suffix: ''
         },
         {
           collection_class: 'Claim::ClaimCollection',
           path: 'claims',
           name: 'claim',
-          plural_name: 'claims'
+          plural_name: 'claims',
+          operations: ['changed'],
+          event_suffix: ''
+        },
+        {
+          collection_class: 'OrderCollection',
+          path: 'orders',
+          name: 'order',
+          plural_name: 'orders',
+          operations: ['changed', 'signedoff'],
+          event_suffix: '/events'
         }
       ].freeze
 
       SUBSCRIPTION_TYPES.each do |subscription_type|
-        define_method("#{subscription_type[:name]}_subscription") do |practice_id:, params: {}|
-          response = @api.call(
-            endpoint: "#{practice_id}/#{subscription_type[:path]}/changed/subscription",
-            method: :get,
-            params: params
-          )
+        subscription_type[:operations].each do |operation|
+          subscription_name = subscription_name(subscription_type:, operation:)
 
-          Subscription.new(response)
-        end
+          define_method("#{subscription_name}_subscription") do |practice_id:, params: {}|
+            response = @api.call(
+              endpoint: "#{practice_id}/#{subscription_type[:path]}/#{operation}/subscription",
+              method: :get,
+              params: params
+            )
 
-        define_method("create_#{subscription_type[:name]}_subscription") do |practice_id:, params: {}|
-          @api.call(
-            endpoint: "#{practice_id}/#{subscription_type[:path]}/changed/subscription",
-            method: :post,
-            params: params
-          )
-        end
+            Subscription.new(response)
+          end
 
-        define_method("changed_#{subscription_type[:plural_name]}") do |practice_id:, department_id: nil, params: {}|
-          params[:departmentid] = department_id unless department_id.nil?
-          response = @api.call(
-            endpoint: "#{practice_id}/#{subscription_type[:path]}/changed",
-            method: :get,
-            params: params
-          )
-          Object.const_get('AthenaHealth').const_get((subscription_type[:collection_class]).to_s).new(response)
+          define_method("create_#{subscription_name}_subscription") do |practice_id:, params: {}|
+            @api.call(
+              endpoint: "#{practice_id}/#{subscription_type[:path]}/#{operation}/subscription",
+              method: :post,
+              params: params
+            )
+          end
+
+          define_method("#{operation}_#{subscription_type[:plural_name]}") do |practice_id:, department_id: nil, params: {}|
+            params[:departmentid] = department_id unless department_id.nil?
+            response = @api.call(
+              endpoint: "#{practice_id}/#{subscription_type[:path]}/#{operation}#{subscription_type[:event_suffix]}",
+              method: :get,
+              params: params
+            )
+            Object.const_get('AthenaHealth').const_get((subscription_type[:collection_class]).to_s).new(response)
+          end
         end
+      end
+
+      def subscription_name(subscription_type:, operation:)
+        return subscription_type[:name] if operation == 'changed'
+
+        "#{operation}_#{subscription_type[:name]}"
       end
     end
   end

--- a/spec/fixtures/vcr_cassettes/order_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/order_subscription.yml
@@ -1,0 +1,263 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/subscription
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Typhoeus - https://github.com/typhoeus/typhoeus
+        Authorization:
+          - Bearer wbbdxswq2k5apunamqky5ham
+        Expect:
+          - ""
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store
+        Cneonction:
+          - close
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Wed, 11 Mar 2020 19:03:51 GMT
+        Expires:
+          - Mon, 06 Jan 1975 16:00:00 GMT
+        Pragma:
+          - No-cache
+        Server:
+          - Apache
+        Set-Cookie:
+          - dtCookie=0CF22FF41F1880C32B46643210B6718F|RUM+Default+Application|1; Path=/;
+            Domain=.athenahealth.com
+        Vary:
+          - Accept-Encoding
+        X-Mashery-Message-ID:
+          - ed7d9d0d-8f2a-430c-a178-8348150e12f0
+        X-Mashery-Responder:
+          - prod-j-worker-us-east-1e-69.mashery.com
+        Content-Length:
+          - "16"
+        Connection:
+          - keep-alive
+      body:
+        encoding: UTF-8
+        string: '{"success":true}'
+      http_version: "1.1"
+      adapter_metadata:
+        effective_url: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/subscription
+    recorded_at: Wed, 11 Mar 2020 19:03:49 GMT
+  - request:
+      method: get
+      uri: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/events?departmentid=1
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Typhoeus - https://github.com/typhoeus/typhoeus
+        Authorization:
+          - Bearer wbbdxswq2k5apunamqky5ham
+        Expect:
+          - ""
+    response:
+      status:
+        code: 403
+        message: Forbidden
+      headers:
+        Cneonction:
+          - close
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 11 Mar 2020 19:03:51 GMT
+        Pragma:
+          - No-cache
+        Server:
+          - Apache
+        Set-Cookie:
+          - dtCookie=58F0D7C790471FD603FF09F49796C8C1|RUM+Default+Application|1; Path=/;
+            Domain=.athenahealth.com
+        Vary:
+          - Accept-Encoding
+        X-Mashery-Message-ID:
+          - 6080fb39-df3a-49ae-bcc6-063d5d70189c
+        X-Mashery-Responder:
+          - prod-j-worker-us-east-1e-65.mashery.com
+        transfer-encoding:
+          - chunked
+        Connection:
+          - keep-alive
+      body:
+        encoding: UTF-8
+      encoding: UTF-8
+      string: |2-
+
+
+        {"error":"Changed messages require setup (subscription) that has not been done."}
+      http_version: "1.1"
+      adapter_metadata:
+        effective_url: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/events?departmentid=1
+    recorded_at: Wed, 11 Mar 2020 19:03:49 GMT
+  - request:
+      method: get
+      uri: https://api.preview.platform.athenahealth.com/v1/123456/orders/changed/subscription
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Typhoeus - https://github.com/typhoeus/typhoeus
+        Authorization:
+          - Bearer wbbdxswq2k5apunamqky5ham
+        Expect:
+          - ""
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store
+        Cneonction:
+          - close
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Wed, 11 Mar 2020 19:03:51 GMT
+        Expires:
+          - Mon, 06 Jan 1975 16:00:00 GMT
+        Pragma:
+          - No-cache
+        Server:
+          - Apache
+        Set-Cookie:
+          - dtCookie=48DC79BF7889F5210002147DC2C59E72|RUM+Default+Application|1; Path=/;
+            Domain=.athenahealth.com
+        Vary:
+          - Accept-Encoding
+        X-Mashery-Message-ID:
+          - eafee5ad-9a1a-4d2b-8a30-95816210fa0b
+        X-Mashery-Responder:
+          - prod-j-worker-us-east-1d-58.mashery.com
+        Content-Length:
+          - "40"
+        Connection:
+          - keep-alive
+      body:
+        encoding: UTF-8
+        string: '{"status":"INACTIVE","subscriptions":[]}'
+      http_version: "1.1"
+      adapter_metadata:
+        effective_url: https://api.preview.platform.athenahealth.com/v1/123456/orders/changed/subscription
+    recorded_at: Wed, 11 Mar 2020 19:03:50 GMT
+  - request:
+      method: get
+      uri: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/events?departmentid=1
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Typhoeus - https://github.com/typhoeus/typhoeus
+        Authorization:
+          - Bearer wbbdxswq2k5apunamqky5ham
+        Expect:
+          - ""
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store
+        Cneonction:
+          - close
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Wed, 11 Mar 2020 19:08:10 GMT
+        Expires:
+          - Mon, 06 Jan 1975 16:00:00 GMT
+        Pragma:
+          - No-cache
+        Server:
+          - Apache
+        Set-Cookie:
+          - dtCookie=53FC7A9C0FBEF316FDC347CD43A14BB5|RUM+Default+Application|1; Path=/;
+            Domain=.athenahealth.com
+        Vary:
+          - Accept-Encoding
+        X-Mashery-Message-ID:
+          - 4da03080-d949-40d3-b781-1326f1f34cb4
+        X-Mashery-Responder:
+          - prod-j-worker-us-east-1e-67.mashery.com
+        Content-Length:
+          - "31"
+        Connection:
+          - keep-alive
+      body:
+        encoding: UTF-8
+        string: '{"orders":[],"totalcount":0}'
+      http_version: "1.1"
+      adapter_metadata:
+        effective_url: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/events?departmentid=1
+    recorded_at: Wed, 11 Mar 2020 19:08:08 GMT
+  - request:
+      method: get
+      uri: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/subscription
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Typhoeus - https://github.com/typhoeus/typhoeus
+        Authorization:
+          - Bearer wbbdxswq2k5apunamqky5ham
+        Expect:
+          - ""
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Wed, 11 Mar 2020 19:18:03 GMT
+        Expires:
+          - Mon, 06 Jan 1975 16:00:00 GMT
+        nnCoection:
+          - close
+        Pragma:
+          - No-cache
+        Server:
+          - Apache
+        Set-Cookie:
+          - dtCookie=192458D0333365D5DAFBF81C2F5E86E5|RUM+Default+Application|1; Path=/;
+            Domain=.athenahealth.com
+        Vary:
+          - Accept-Encoding
+        X-Mashery-Message-ID:
+          - f1a86201-572e-43b0-ac01-113640be54ca
+        X-Mashery-Responder:
+          - prod-j-worker-us-east-1e-64.mashery.com
+        Content-Length:
+          - "160"
+        Connection:
+          - keep-alive
+      body:
+        encoding: UTF-8
+        string: '{"status":"ACTIVE","subscriptions":[{"eventname"=>"OrderSignOffNotify"}]}'
+      http_version: "1.1"
+      adapter_metadata:
+        effective_url: https://api.preview.platform.athenahealth.com/v1/195900/orders/changed/subscription
+    recorded_at: Wed, 11 Mar 2020 19:18:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/endpoints/subscriptions/order_spec.rb
+++ b/spec/lib/endpoints/subscriptions/order_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AthenaHealth::Endpoints::Subscriptions do
+  let(:attributes) do
+    {
+      practice_id: 195_900,
+      department_id: 1
+    }
+  end
+
+  describe 'order subscriptions' do
+    describe '#create_order_subscription' do
+      it 'returns success => true' do
+        VCR.use_cassette('order_subscription') do
+          expect(client.create_order_subscription(
+                   practice_id: 195_900
+                 )).to eq 'success' => true
+        end
+      end
+    end
+
+    describe '#changed_orders' do
+      it 'returns instance of ProviderCollection' do
+        VCR.use_cassette('order_subscription') do
+          expect(client.changed_providers(
+                   practice_id: 195_900,
+                   department_id: 1
+                 )).to be_an_instance_of AthenaHealth::ProviderCollection
+        end
+      end
+    end
+
+    describe '#order_subscription' do
+      it 'returns instance of an active Subscription' do
+        VCR.use_cassette('order_subscription') do
+          subscription = client.order_subscription(
+            practice_id: 195_900
+          )
+          expect(subscription).to be_an_instance_of AthenaHealth::Subscription
+          expect(subscription.events).to match_array(%w[ProviderAdd ProviderDelete ProviderUndelete ProviderUpdate])
+          expect(subscription.active?).to equal(true)
+        end
+      end
+
+      it 'returns instance of an inactive Subscription' do
+        VCR.use_cassette('order_subscription') do
+          subscription = client.order_subscription(
+            practice_id: 123_456
+          )
+          expect(subscription).to be_an_instance_of AthenaHealth::Subscription
+          expect(subscription.events).to match_array([])
+          expect(subscription.active?).to equal(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to add support  for Order  Subscription.

While also adding custom operations, to support `sigined off` orders, while keeping backward compatibility for the `change` operation.

Add methods:
- `signedoff_order_subscription`
- `create_signedoff_order_subscription`
- `signedoff_orders`

Refernce of the subscription at:

- https://docs.athenahealth.com/api/resources/api-change-51922-updated-endpoints-modality-code-added-orderssignedoff-endpoint
- https://docs.athenahealth.com/api/guides/changed-data-subscriptions#Important_Notes__Best_Practices_5
- https://docs.athenahealth.com/api/api-ref/document-type-order
- https://docs.athenahealth.com/api/workflows/chronic-care-management 


![image](https://github.com/user-attachments/assets/58eb6924-6e82-417d-9750-c41c293093f9)

